### PR TITLE
Fix broken links

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -56,29 +56,29 @@ Pull requests are welcome. Thank you. 💙
 
 - gives a file tree view on the side of each repository that you visit that you can use to navigate over the codebase
 
-<h2 align="center"> <a href="https:https://github.com/fantattitude/refined-github-safari"> Refined GitHub</a></h2>
+<h2 align="center"> <a href="https://github.com/fantattitude/refined-github-safari"> Refined GitHub</a></h2>
 
 - some small UI and usability improvements on the [Github](https://github.com/) website
 
-<h2 align="center"> <a href="https:https://github.com/honestbleeps/Reddit-Enhancement-Suite"> Reddit Enchancement Suite </a></h2>
+<h2 align="center"> <a href="https://github.com/honestbleeps/Reddit-Enhancement-Suite"> Reddit Enchancement Suite </a></h2>
 
 - a ton of amazing additions to the [Reddit](http://www.reddit.com/) website
 
 
-<h2 align="center"> <a href="https:https://hckrnews.com/about.html#extensions"> Hckr News</a></h2>
+<h2 align="center"> <a href="https://hckrnews.com/about.html#extensions"> Hckr News</a></h2>
 
 - an interface change to [hacker news](https://news.ycombinator.com/) focusing on content and reducing visual noise
 
-<h2 align="center"> <a href="https:https://sessions-extension.github.io/Sessions/"> Sessions</a></h2>
+<h2 align="center"> <a href="https://sessions-extension.github.io/Sessions/"> Sessions</a></h2>
 
 - allows you to quickly save and retrieve sessions that you made
 - very useful if you have many tabs open and don't want to quit them all but still want to start a new session to work from
 
-<h2 align="center"> <a href="https:http://socialfixer.com/download.html"> Social Fixer</a></h2>
+<h2 align="center"> <a href="http://socialfixer.com/download.html"> Social Fixer</a></h2>
 
 - allows you to really clean up the clutter from the Facebook home page
 
-<h2 align="center"> <a href="https:https://disconnect.me/"> Disconnect</a></h2>
+<h2 align="center"> <a href="https://disconnect.me/"> Disconnect</a></h2>
 
 - adds an extra layer of security on top of [Adguard blocker](https://adguard.com/en/adblock-adguard-safari.html) 
 
@@ -86,27 +86,27 @@ Pull requests are welcome. Thank you. 💙
 
 - enchances [Twitch](http://twitch.tv/) website by adding night mode + few more features
 
-<h2 align="center"> <a href="https:http://nomoreitunes.einserver.de/"> noMoreItunes </a></h2>
+<h2 align="center"> <a href="http://nomoreitunes.einserver.de/"> noMoreItunes </a></h2>
 
 - Safari redirects you to iTunes every time you click on some iTunes link or an App Store App, this stops that
 
-<h2 align="center"> <a href="https:https://agilebits.com/onepassword/extensions"> 1Password </a></h2>
+<h2 align="center"> <a href="https://agilebits.com/onepassword/extensions"> 1Password </a></h2>
 
 - [1Password](https://1password.com) is a phenomenal password manager, this extension just gives a seamless interaction of it with the browser
 
-<h2 align="center"> <a href="https:http://safariextendr.com/extension/reddit-comments"> Reddit Comments </a></h2>
+<h2 align="center"> <a href="http://safariextendr.com/extension/reddit-comments"> Reddit Comments </a></h2>
 
 - provides a small button in the top toolbar that when clicked will direct you to a reddit thread where the current page you are on was submitted to, if such page exists of course
 
-<h2 align="center"> <a href="https:http://scroblr.fm/"> Scroblr</a></h2>
+<h2 align="center"> <a href="http://scroblr.fm/"> Scroblr</a></h2>
 
 - allows you to scrobble songs you listen to from Youtube, Soundcloud to your [last.fm](http://last.fm) account
 
-<h2 align="center"> <a href="https:https://github.com/rfletcher/safari-json-formatter"> JSON formatter </a></h2>
+<h2 align="center"> <a href="https://github.com/rfletcher/safari-json-formatter"> JSON formatter </a></h2>
 
 - makes JSON documents that you open with the browser 'human readable' by formatting them nicely
 
-<h2 align="center"> <a href="https:http://open-bits.com/shellfish/"> Shellfish</a></h2>
+<h2 align="center"> <a href="http://open-bits.com/shellfish/"> Shellfish</a></h2>
 
 - removes all the annoying 'share this page' links and buttons from the Internet
 


### PR DESCRIPTION
Some of the links were broken because of "https:" prefix while there was already https:// or http://