### PR TITLE
Move deprecated extensions to new category

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -2,17 +2,14 @@
 
 _Please read [contribution guidelines](contributing.md) before contributing._
 
-- [Developer](#developer)
-- [General](#general)
-- [Music](#music)
-- [Social](#social)
-- [Related](#related)
+  - [Developer](#developer)
+  - [General](#general)
+  - [Social](#social)
+  - [Deprecated](#deprecated)
+  - [Related](#related)
 
 ## Developer
 
-- [Awesome Autocomplete For Github](https://github.com/algolia/github-awesome-autocomplete) - Adds autocomplete for GitHub's search bar.
-- [JSON Formatter](https://github.com/rfletcher/safari-json-formatter) - Makes JSON documents that you open with the browser 'human readable' by formatting them nicely.
-- [XML Viewer](https://github.com/sergeche/xmlview) - Powerful XML viewer.
 - [SourceKit](https://github.com/kishikawakatsumi/SourceKitForSafari) - Enables IDE features on your browser such as symbol navigator, go to definition and documentation on hover.
 
 ## General
@@ -20,27 +17,11 @@ _Please read [contribution guidelines](contributing.md) before contributing._
 - [Ultra TabSaver](https://github.com/morsamatias/UltraTabSaver) The Open Source Tab Manager for Safari
 - [1Password](https://agilebits.com/onepassword/extensions) - [1Password](https://1password.com) is a phenomenal password manager, this extension just gives a seamless interaction of it with the browser.
 - [AdGuard](https://adguard.com/en/adblock-adguard-safari.html) - Ad content blocker that uses [Safari native content blocking API's](https://developer.apple.com/library/content/documentation/Extensions/Conceptual/ContentBlockingRules/Introduction/Introduction.html).
-- [AlienTube](https://github.com/mabako/alientube) - Youtube comments are useless, this shows Reddit comments on videos that were submitted to Reddit.
 - [BetterTTV](https://nightdev.com/betterttv/) - Enchances [Twitch](http://twitch.tv/) website by adding night mode + few more features.
-- [DirectLinks](http://canisbos.com/) - Makes indirect links on Google and Facebook direct.
-- [GitHub Highlight Selected](https://github.com/Nuclides/github-highlight-selected) - Highlights selected word in GitHub source view like Sublime Text.
-- [Hckr News](https://hckrnews.com/about.html#extensions) - An interface change to [hacker news](https://news.ycombinator.com/) focusing on content and reducing visual noise.
-- [JS Blocker](http://jsblocker.toggleable.com/) - Use user scripts to make websites work how you want them to.
-- [Newsfeed Eradicator](http://antonosika.github.io/newsfeed-eradicator/) - Lets you use Facebook without being distracted by the newsfeed.
 - [Nightlight](https://github.com/Gofake1/Nightlight) - In the case where there is no Stylish theme available, you can turn on a permanenet night theme mode with this extension. It attempts to bring night theme mode to websites that don't natively support it.
-- [NoMoreiTunes](http://nomoreitunes.einserver.de/) - Safari redirects you to iTunes every time you click on some iTunes link or an App Store App, this stops that.
 - [Octotree](https://github.com/buunguyen/octotree) - Gives a file tree view on the side of each repository that you visit that you can use to navigate over the codebase.
-- [Pixave](http://www.littlehj.com/Pixave.safariextz) - Extension for [Pixave](http://www.littlehj.com/mac/) app.
-- [Recent Tab List](http://nickvdp.com/tablist/) - Keeps track of recently closed tabs and allows you to reopen them quickly.
-- [Reddit Comments](http://safariextendr.com/extension/reddit-comments) - Provides a small button in the top toolbar that when clicked will direct you to a reddit thread where the current page you are on was submitted to, if such page exists of course.
-- [Reddit Enchancement Suite ](https://github.com/honestbleeps/Reddit-Enhancement-Suite) - A ton of amazing additions to the [Reddit](http://www.reddit.com/) website.
 - [Refined GitHub](https://github.com/lautis/refined-github-safari) - Some small UI and usability improvements on the [Github](https://github.com/) website.
 - [Select](https://github.com/makoni/select-like-a-boss-for-safari) - Allows you to select text inside links.
-- [Sessions](https://sessions-extension.github.io/Sessions/) - Allows you to quickly save and retrieve sessions that you made. Very useful if you have many tabs open and don't want to quit them all but still want to start a new session to work from.
-- [Shellfish](http://open-bits.com/shellfish/) - Removes all the annoying 'share this page' links and buttons from the Internet.
-- [Stylish](http://sobolev.us/stylish/) - Allows for local customisations of various websites. [Here](https://wiki.nikitavoloboev.xyz/web/browsers/stylish.html) are some example night themes you can set up to use from it.
-- [sVim](https://github.com/flipxfx/sVim) - Adds a custom layer of keybinds you can customise to personalise your browsing experience. [Here](https://gist.github.com/c26e6a05e4e426e0542e55b7513b581c) is an example of config you might make.
-- [Tab Options](http://canisbos.com/taboptions) - Adds a few tab-related options to the ones built into Safari.
 - [Translate](http://sidetree.com/extensions.html#Translate) - Automatically translate entire webpages into your prefered language as you browse.
 - [Turn Off the Lights for Safari](https://www.turnoffthelights.com) - Turn Off the Lights extension highlight the video player content with one click on the gray lamp button.
 - [Accelerate for Safari](https://itunes.apple.com/us/app/accelerate-for-safari/id1459809092?mt=12) - Control video speed in Safari.
@@ -48,13 +29,28 @@ _Please read [contribution guidelines](contributing.md) before contributing._
 - [Safarikai](https://github.com/ashchan/safarikai) - Safari extension for translating Japanese words.
 - [Zoom In](https://github.com/nothingmagical/ZoomIn) - Automatically open Zoom links.
 
-## Music
-
-- [Scroblr](http://scroblr.fm/) - Allows you to scrobble songs you listen to from Youtube, Soundcloud to your [last.fm](http://last.fm) account.
-
 ## Social
 
 - [Social Fixer](http://socialfixer.com/download.html) - Allows you to really clean up the clutter from the Facebook home page.
+
+## Deprecated
+
+These extensions have not been updated for Safari 13 and thus do not work with the latest version and are considered deprecated
+
+- [Awesome Autocomplete For Github](https://github.com/algolia/github-awesome-autocomplete) - Adds autocomplete for GitHub's search bar.
+- [JSON Formatter](https://github.com/rfletcher/safari-json-formatter) - Makes JSON documents that you open with the browser 'human readable' by formatting them nicely.
+- [XML Viewer](https://github.com/sergeche/xmlview) - Powerful XML viewer.
+- [AlienTube](https://github.com/mabako/alientube) - Youtube comments are useless, this shows Reddit comments on videos that were submitted to Reddit.
+- [GitHub Highlight Selected](https://github.com/Nuclides/github-highlight-selected) - Highlights selected word in GitHub source view like Sublime Text.
+- [Hckr News](https://hckrnews.com/about.html#extensions) - An interface change to [hacker news](https://news.ycombinator.com/) focusing on content and reducing visual noise.
+- [JS Blocker](http://jsblocker.toggleable.com/) - Use user scripts to make websites work how you want them to.
+- [Newsfeed Eradicator](http://antonosika.github.io/newsfeed-eradicator/) - Lets you use Facebook without being distracted by the newsfeed.
+- [NoMoreiTunes](http://nomoreitunes.einserver.de/) - Safari redirects you to iTunes every time you click on some iTunes link or an App Store App, this stops that.
+- [Pixave](http://www.littlehj.com/Pixave.safariextz) - Extension for [Pixave](http://www.littlehj.com/mac/) app.
+- [Recent Tab List](http://nickvdp.com/tablist/) - Keeps track of recently closed tabs and allows you to reopen them quickly.
+- [Sessions](https://sessions-extension.github.io/Sessions/) - Allows you to quickly save and retrieve sessions that you made. Very useful if you have many tabs open and don't want to quit them all but still want to start a new session to work from.
+- [Shellfish](http://open-bits.com/shellfish/) - Removes all the annoying 'share this page' links and buttons from the Internet.
+- [sVim](https://github.com/flipxfx/sVim) - Adds a custom layer of keybinds you can customise to personalise your browsing experience. [Here](https://gist.github.com/c26e6a05e4e426e0542e55b7513b581c) is an example of config you might make.
 
 ## Related
 


### PR DESCRIPTION
Resolves #6 

--
Also removes extensions with dead links or with no more Safari version